### PR TITLE
FIX getOriginalWidth/Height() methods mixed up

### DIFF
--- a/code/Imgix.php
+++ b/code/Imgix.php
@@ -562,7 +562,7 @@ class Imgix extends Image {
     }
 
     public function getOriginalWidth() {
-        return $this->getDimensions(1);
+        return $this->getDimensions(0);
     }
 
     /**
@@ -575,7 +575,7 @@ class Imgix extends Image {
     }
 
     public function getOriginalHeight() {
-        return $this->getDimensions(0);
+        return $this->getDimensions(1);
     }
 
     /**


### PR DESCRIPTION
`getOriginalWidth()` and `getOriginalHeight()` are returning the wrong values. Looking at the parent `Image` class, they have been setup the wrong way around which is resulting in `getOrientation()` etc returning the wrong values.