### PR TITLE
FIX missing use Convert

### DIFF
--- a/src/Imgix.php
+++ b/src/Imgix.php
@@ -3,6 +3,7 @@
 namespace PlatoCreative\Imgix;
 
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Convert;
 use SilverStripe\Assets\Image;
 use Imgix\UrlBuilder;
 


### PR DESCRIPTION
Imgix::getTag() breaks due to a missing use statement for the Convert class