### PR TITLE
Fix/asset admin missing thumbnails

### DIFF
--- a/_config/imgix.yml
+++ b/_config/imgix.yml
@@ -1,0 +1,12 @@
+---
+Name: imgix
+After: assetadmingraphql-dependencies
+---
+
+# Fixes assets-admin module from assuming thumbnails already exist
+# as they never will due to them being hosted on the CDN
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\AssetAdmin\Model\ThumbnailGenerator.graphql:
+    class: SilverStripe\AssetAdmin\Model\ThumbnailGenerator
+    properties:
+      Generates: true


### PR DESCRIPTION
assets-admin assumes thumbnails will already exist and doesn't mark them for 'generation'. As our resampled images are stored on the CDN they never locally exist, so need to be 'generated'.